### PR TITLE
Enable passing a url as callback url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,11 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+
+*.xml
+
+.idea/.name
+
+.idea/.rakeTasks
+
+*.iml

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ Start a Conversion on Cloud convert
 
 	conversion = Cloudconvert::Conversion.new
 
-	# to start file conversion (options parameter is optional)
-	conversion.convert(inputformat, outputformat, file_path, options)  
+	# to start file conversion (options & callback_url parameters are optional)
+	conversion.convert(inputformat, outputformat, file_path, callback_url, options)
 
 	# options parameter is Conversion type specific options , which you can get from, 
 	conversion.converter_options(inputformat, outputformat)

--- a/lib/cloudconvert/conversion.rb
+++ b/lib/cloudconvert/conversion.rb
@@ -1,112 +1,109 @@
 module Cloudconvert
 	class Conversion
-    	attr_accessor :convert_request_url, :conn , :request_connection, :process_id, :conversion_connection
+    attr_accessor :convert_request_url, :conn , :request_connection, :process_id, :conversion_connection
 
-        #request_connection => specific to file conversion
+      #request_connection => specific to file conversion
 
-    	def initialize 
-            raise Cloudconvert::API_KEY_ERROR if Cloudconvert.configuration.api_key == nil
-    		@conversion_connection = Faraday.new(:url => Cloudconvert::CONVERSION_URL)
-    	end
+    def initialize
+          raise Cloudconvert::API_KEY_ERROR if Cloudconvert.configuration.api_key == nil
+      @conversion_connection = Faraday.new(:url => Cloudconvert::CONVERSION_URL)
+    end
 
-        #convert request for file 
-    	def convert(inputformat, outputformat, file_path = nil, options = {})
-            raise "File path cant be blank" if file_path == nil
-            @convert_request_url = start_conversion(inputformat, outputformat)
-            #initiate connection with new response host
-    		initiate_connection(@convert_request_url)
-            upload(build_upload_params(file_path, outputformat, options))
-    	end
+      #convert request for file
+    def convert(inputformat, outputformat, file_path, callback_url = nil, options = {})
+      raise "File path cant be blank" if file_path.nil?
+      @convert_request_url = start_conversion(inputformat, outputformat)
+      #initiate connection with new response host
+      initiate_connection(@convert_request_url)
+      upload(build_upload_params(file_path, outputformat, callback_url, options))
+    end
 
-        #lists all conversions
-    	def list_conversions
-    	   response = @conversion_connection.get '/processes', {:apikey => api_key } 
-    	   parse_response(response.body)
-    	end
-    		
-
-    	#cancels current conversion
-    	def cancel_conversion
-    	   response = @request_connection.get "/process/#{@process_id.to_s}/cancel"
-           parse_response(response.body)
-    	end
-
-    	#deletes finished conversion
-		def delete_conversion
-    		response = @request_connection.get "/process/#{@process_id.to_s}/delete" 
-            parse_response(response.body)
-    	end
-
-        #upload request
-        def upload(upload_params)
-            response = @request_connection.post "/process/#{@process_id.to_s}", upload_params
-            parse_response(response.body)
-        end
+      #lists all conversions
+    def list_conversions
+       response = @conversion_connection.get '/processes', {:apikey => api_key }
+       parse_response(response.body)
+    end
 
 
-        # checks if conversion finished for process id and returns download link
-        def download_link
-            response = status
-            response["step"] == "finished" ? "http:#{response['output']['url']}" : nil
-        end 
+    #cancels current conversion
+    def cancel_conversion
+      response = @request_connection.get "/process/#{@process_id.to_s}/cancel"
+      parse_response(response.body)
+    end
 
-        # checks status of conversion with process_id
-        def status
-            response = @request_connection.get "/process/#{@process_id.to_s}"
-            parse_response(response.body)
-        end
+    #deletes finished conversion
+    def delete_conversion
+      response = @request_connection.get "/process/#{@process_id.to_s}/delete"
+      parse_response(response.body)
+    end
 
-    	#returns all possible conversions and options
-    	def converter_options(inputformat ="", outputformat = "")
-    		response = @conversion_connection.get "conversiontypes", {:inputformat => inputformat,:outputformat => outputformat } 
-            parse_response(response.body)
-    	end
+    #upload request
+    def upload(upload_params)
+      response = @request_connection.post "/process/#{@process_id.to_s}", upload_params
+      parse_response(response.body)
+    end
 
 
-        #######################################################################################################
-        #######################################################################################################
-        def api_key
-            raise Cloudconvert::API_KEY_ERROR if Cloudconvert.configuration.api_key == nil
-            Cloudconvert.configuration.api_key
-        end
+    # checks if conversion finished for process id and returns download link
+    def download_link
+      response = status
+      response["step"] == "finished" ? "http:#{response['output']['url']}" : nil
+    end
 
-        def callback
-            Cloudconvert.configuration.callback
-        end
+    # checks status of conversion with process_id
+    def status
+      response = @request_connection.get "/process/#{@process_id.to_s}"
+      parse_response(response.body)
+    end
 
-    	#send conversion http request
-    	def conversion_post_request(inputformat, outputformat)
-            @conversion_connection.post "https://api.cloudconvert.org/process?inputformat=#{inputformat}&outputformat=#{outputformat}&apikey=#{api_key}"
-    	end
+    #returns all possible conversions and options
+    def converter_options(inputformat ="", outputformat = "")
+      response = @conversion_connection.get "conversiontypes", {:inputformat => inputformat,:outputformat => outputformat }
+      parse_response(response.body)
+    end
 
-        def start_conversion(inputformat, outputformat)
-            response = conversion_post_request(inputformat,outputformat)
+    def api_key
+      raise Cloudconvert::API_KEY_ERROR if Cloudconvert.configuration.api_key == nil
+      Cloudconvert.configuration.api_key
+    end
 
-            parsed_response = parse_response(response.body)
-            @process_id = parsed_response["id"]
+    def callback
+      Cloudconvert.configuration.callback
+    end
 
-            "https://#{parsed_response['host']}"
-        end
+    #send conversion http request
+    def conversion_post_request(inputformat, outputformat)
+        @conversion_connection.post "https://api.cloudconvert.org/process?inputformat=#{inputformat}&outputformat=#{outputformat}&apikey=#{api_key}"
+    end
 
-        def initiate_connection(url)
-            @request_connection = Faraday.new(:url => url)
-        end
+    def start_conversion(inputformat, outputformat)
+      response = conversion_post_request(inputformat,outputformat)
 
-        #building params for local file
-        def build_upload_params(file_path, outputformat, options = {})
-            upload_params = { :format => outputformat}
-            upload_params.merge!(:callback => callback) if callback != nil
-            upload_params.merge!(:input => "download",:link => file_path ) 
-            upload_params.merge!(options)
-        end
+      parsed_response = parse_response(response.body)
+      @process_id = parsed_response["id"]
 
-    	def parse_response(response)
-    		JSON.parse(response)
-    	end
+      "https://#{parsed_response['host']}"
+    end
 
-        #######################################################################################################
-        #######################################################################################################
+    def initiate_connection(url)
+      @request_connection = Faraday.new(:url => url)
+    end
+
+    #building params for local file
+    def build_upload_params(file_path, outputformat, callback_url = nil, options = {})
+      upload_params = { :format => outputformat}
+      if callback_url != nil
+        upload_params.merge!(:callback => callback_url)
+      elsif callback != nil
+        upload_params.merge!(:callback => callback)
+      end
+      upload_params.merge!(:input => "download",:link => file_path )
+      upload_params.merge!(options)
+    end
+
+    def parse_response(response)
+      JSON.parse(response)
+    end
 
 	end
-	
 end


### PR DESCRIPTION
Currently there is only one callback, the one on the config.
My change is enabling the user to set mulitple callbacks, as the callback is a parameter.
This will help for instance when I have a model `File` where I convert a doc to an image,
so the callback on my controller would look like:

``` /files/:id/convert```
and I will pass it to cloudconvert as a callback (/files/12/convert).

Also, did some cleanups and indentations.
```
