### PR TITLE
rewrite using faraday middleware

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,5 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in cloudconvert.gemspec
 gemspec
 
-gem "faraday"
-gem "json"
+gem 'faraday', '~> 0.9.0'
+gem 'faraday_middleware', '~> 0.9.1'

--- a/lib/cloudconvert.rb
+++ b/lib/cloudconvert.rb
@@ -1,15 +1,17 @@
 require "cloudconvert/version"
 require "cloudconvert/configuration"
+require "cloudconvert/client"
 require "cloudconvert/conversion"
 
 require "faraday"
-require "json"
+require 'faraday_middleware'
 
 module Cloudconvert
-  # Your code goes here...
+
   CONVERSION_URL = "https://api.cloudconvert.org/"
 
   API_KEY_ERROR = "API Key cant be blank!"
+
   Cloudconvert.configure
 
 end

--- a/lib/cloudconvert/client.rb
+++ b/lib/cloudconvert/client.rb
@@ -1,0 +1,23 @@
+module Cloudconvert
+  class Client
+    # Faraday middleware
+    def initialize
+      raise API_KEY_ERROR if Cloudconvert.configuration.api_key.nil?
+
+      @conn ||= Faraday.new(url: Cloudconvert::CONVERSION_URL) do |faraday|
+        faraday.request 			:json
+        faraday.response			:json, content_type: /\bjson$/
+        faraday.response			:logger
+        faraday.adapter 			Faraday.default_adapter
+      end
+    end
+
+    def post(url, payload)
+      @conn.post(url, payload).body
+    end
+
+    def get(url)
+      @conn.get(url).body
+    end
+  end
+end


### PR DESCRIPTION
Hi,

I have re-written the Conversion class using faraday_middleware. I think it's easier this way.

A few examples:

```
#!/usr/bin/env ruby

require 'cloudconvert'

Cloudconvert.configure do |config|
    # config.api_key  = 'your api key'
end

# Example:
#
# Convert remote web hosted document from markdown to pdf
# with: - email confirmation
#       - dropbox delivery

conv = Cloudconvert::Conversion.new('md', 'pdf')
conv.newProcess

conversion_options = {
  file: 'http://example.com/file.md',
  filename: 'file.md',
  email: '1',
  output: 'dropbox'
}
conv.conversion_payload(conversion_options)
conv.remoteFile

step = conv.status['step']

while !(step =~ /error|finished/)
  step = conv.status['step']
  puts step
  sleep 2
end

puts "File conerted successfully, url:'http:#{conv.status['output']['url']}'"


# Example:
#
# - get current conversion types

# conv = Cloudconvert::Conversion.new('md', "pdf")
puts conv.current_conversion_types

# - get all conversion types
# puts "\n\n**********************\n\n"
# puts conv.conversion_types

# - get mp3 conversion types
puts "\n\n**********************\n\n"
puts conv.conversion_types('mp3')

```

Please, let me know if you're interested in these changes.
I'll try to add AWS S3 support as well.
